### PR TITLE
Implementar login com google e verificar tokens

### DIFF
--- a/functions/_lib/migrations.ts
+++ b/functions/_lib/migrations.ts
@@ -1,0 +1,64 @@
+export interface Env {
+	DB: D1Database;
+}
+
+interface Migration {
+	version: string;
+	statements: string[];
+}
+
+const migrations: Migration[] = [
+	{
+		version: '2024-08-15_auth_v1',
+		statements: [
+			`CREATE TABLE IF NOT EXISTS users (
+				id TEXT PRIMARY KEY,
+				email TEXT NOT NULL UNIQUE,
+				pass_hash TEXT NOT NULL,
+				username TEXT,
+				created_at INTEGER NOT NULL,
+				email_verified INTEGER DEFAULT 0
+			)` ,
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username ON users(username)`
+		]
+	},
+	{
+		version: '2024-08-16_auth_v2_sessions',
+		statements: [
+			`CREATE TABLE IF NOT EXISTS sessions (
+				session_id TEXT PRIMARY KEY,
+				user_id TEXT NOT NULL,
+				created_at INTEGER NOT NULL,
+				expires_at INTEGER NOT NULL,
+				FOREIGN KEY(user_id) REFERENCES users(id)
+			)`
+		]
+	},
+	{
+		version: '2024-08-22_auth_v3_google',
+		statements: [
+			`ALTER TABLE users ADD COLUMN google_sub TEXT`,
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_users_google_sub ON users(google_sub)
+			   WHERE google_sub IS NOT NULL`
+		]
+	},
+];
+
+async function getAppliedVersions(env: Env): Promise<Set<string>> {
+	await env.DB.prepare(`CREATE TABLE IF NOT EXISTS _migrations (version TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)`).run();
+	const rows = await env.DB.prepare(`SELECT version FROM _migrations`).all<{ version: string }>();
+	const set = new Set<string>();
+	for (const row of rows.results || []) set.add(row.version);
+	return set;
+}
+
+export async function ensureMigrations(env: Env): Promise<void> {
+	const applied = await getAppliedVersions(env);
+	for (const m of migrations) {
+		if (applied.has(m.version)) continue;
+		const tx = await env.DB.batch(m.statements.map((sql) => env.DB.prepare(sql)));
+		await env.DB.prepare(`INSERT INTO _migrations(version, applied_at) VALUES (?, ?)`)
+			.bind(m.version, Date.now())
+			.run();
+	}
+}

--- a/functions/api/auth/logout.ts
+++ b/functions/api/auth/logout.ts
@@ -1,0 +1,31 @@
+import { ensureMigrations, type Env } from "../../_lib/migrations";
+
+function parseCookies(request: Request): Record<string, string> {
+	const cookie = request.headers.get('cookie') || '';
+	const map: Record<string, string> = {};
+	for (const part of cookie.split(/;\s*/)) {
+		if (!part) continue;
+		const idx = part.indexOf('=');
+		if (idx === -1) continue;
+		const k = part.slice(0, idx).trim();
+		const v = decodeURIComponent(part.slice(idx + 1));
+		map[k] = v;
+	}
+	return map;
+}
+
+export async function onRequestPost({ env, request }: { env: Env; request: Request }) {
+	await ensureMigrations(env);
+	const cookies = parseCookies(request);
+	const sessionId = cookies['ps_session'];
+	if (sessionId) {
+		await (env as any).DB.prepare(`DELETE FROM sessions WHERE session_id = ?`).bind(sessionId).run();
+	}
+	const headers = new Headers({ 'Content-Type': 'application/json' });
+	// Clear cookie for apex and www
+	const host = new URL(request.url).host;
+	const apex = host.replace(/^www\./, '');
+	const cookieDomain = `.${apex}`;
+	headers.append('Set-Cookie', `ps_session=; Path=/; Domain=${cookieDomain}; HttpOnly; Secure; SameSite=Lax; Max-Age=0`);
+	return new Response(JSON.stringify({ ok: true }), { headers });
+}

--- a/functions/api/auth/me.ts
+++ b/functions/api/auth/me.ts
@@ -1,0 +1,37 @@
+import { ensureMigrations, type Env } from "../../_lib/migrations";
+
+function parseCookies(request: Request): Record<string, string> {
+	const cookie = request.headers.get('cookie') || '';
+	const map: Record<string, string> = {};
+	for (const part of cookie.split(/;\s*/)) {
+		if (!part) continue;
+		const idx = part.indexOf('=');
+		if (idx === -1) continue;
+		const k = part.slice(0, idx).trim();
+		const v = decodeURIComponent(part.slice(idx + 1));
+		map[k] = v;
+	}
+	return map;
+}
+
+export async function onRequestGet({ env, request }: { env: Env; request: Request }) {
+	await ensureMigrations(env);
+	const cookies = parseCookies(request);
+	const sessionId = cookies['ps_session'];
+	if (!sessionId) return new Response(JSON.stringify({ user: null }), { headers: { 'Content-Type': 'application/json' } });
+
+	const now = Date.now();
+	const session = await (env as any).DB.prepare(
+		`SELECT user_id, expires_at FROM sessions WHERE session_id = ?`
+	).bind(sessionId).first<{ user_id: string; expires_at: number }>();
+	if (!session || session.expires_at < now) {
+		return new Response(JSON.stringify({ user: null }), { headers: { 'Content-Type': 'application/json' } });
+	}
+	const user = await (env as any).DB.prepare(
+		`SELECT id, email FROM users WHERE id = ?`
+	).bind(session.user_id).first<{ id: string; email: string }>();
+	if (!user) {
+		return new Response(JSON.stringify({ user: null }), { headers: { 'Content-Type': 'application/json' } });
+	}
+	return new Response(JSON.stringify({ user }), { headers: { 'Content-Type': 'application/json' } });
+}


### PR DESCRIPTION
Add Google login support by implementing D1 migrations and new `me`/`logout` auth endpoints.

This PR enables end-to-end Google authentication by providing the necessary database schema (users, sessions, google_sub) and API endpoints to manage user sessions (`/api/auth/me` to get current user, `/api/auth/logout` to clear session). Existing Google OAuth `start` and `callback` endpoints are now fully supported.

---
<a href="https://cursor.com/background-agent?bcId=bc-f24a2ca3-2a9f-48f6-b27b-763fd837bd97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f24a2ca3-2a9f-48f6-b27b-763fd837bd97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

